### PR TITLE
[BUG] Fixed empty url in html and text mails.

### DIFF
--- a/Classes/Domain/Model/Issue.php
+++ b/Classes/Domain/Model/Issue.php
@@ -207,4 +207,12 @@ class Tx_Voice_Domain_Model_Issue extends Tx_Extbase_DomainObject_AbstractEntity
 	function getScreenshotAsFile() {
 		return base64_decode(substr($this->getScreenshot(),21));
 	}
+
+	/**
+	 * @return string
+	 */
+	public function getUrl() {
+		$data = $this->getCollectDataObject();
+		return (string)$data->jQueryBrowser->url;
+	}
 }

--- a/Resources/Private/Templates/Email/Index.html
+++ b/Resources/Private/Templates/Email/Index.html
@@ -12,7 +12,7 @@ Personaldata:
 
 Related Page:
 
- - <{issue.collectedDataObject.jQueryBrowser.url}>
+ - {issue.url}
 
 ===============================================================================
 

--- a/Resources/Private/Templates/Email/Index.txt
+++ b/Resources/Private/Templates/Email/Index.txt
@@ -9,7 +9,7 @@ Hello Supporter,
 
 *Related Page:*
 
-- <{issue.collectedDataObject.jQueryBrowser.url}>
+- <{issue.url}>
 
 ===============================================================================
 


### PR DESCRIPTION
This issue must also apply to the master branch, as TYPO3.org was using the same templates.

https://forge.typo3.org/issues/59218
